### PR TITLE
fix: 文字列内で同じ文字に対して同じルビを振った場合に文字数のカウントが不正になる不具合を修正しました

### DIFF
--- a/Assets/TMP_Typewriter/TMP_Typewriter.cs
+++ b/Assets/TMP_Typewriter/TMP_Typewriter.cs
@@ -1,6 +1,7 @@
 ﻿using DG.Tweening;
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using TMPro;
 using UnityEngine;
 
@@ -103,7 +104,9 @@ namespace KoganeUnityLib
 					var ruby = match.Groups["ruby"];
 					var kanji = match.Groups["kanji"];
 					m_rubyInfos.Add((ruby.Index + kanji.Value.Length - 3, ruby.Value.Length));
-					text = text.Replace(match.Groups[0].Value, kanji.Value);
+					var patternToFind = Regex.Escape(match.Groups[0].Value);
+					var regex = new Regex(patternToFind);
+					text = regex.Replace(text, kanji.Value, 1);
 					match = TMProRubyUtil.TagRegex.Match(text);
 				}
 				else
@@ -178,7 +181,7 @@ namespace KoganeUnityLib
 			}
 
 			m_textUI.maxVisibleCharacters = rubyAddedCount;
-			
+
 			Debug.Log(value);
 		}
 


### PR DESCRIPTION
```<r=わたし>私</r>と<r=わたし>私</r>の好きなもの```

という文字列に対して処理を実施した場合

```var match = TMProRubyUtil.TagRegex.Match(text);```
で取得した先頭の「<r=わたし>私</r>」のルビ情報をm_rubyInfosに入れた後

```text = text.Replace(match.Groups[0].Value, kanji.Value);```
で全ての「<r=わたし>私</r>」を「私」に置換してしまうため、OnUpdateでのrubyAddedCountへの加算が不十分となり文字列を最後まで表示できない不具合が発生していました

```text.Replace```で全てを置換するのではなく```regex.Replace```で1つずつ置換することによって、同じ漢字と同じルビの組み合わせがあっても正常に動作するようにしました